### PR TITLE
Fix pascalvoc converter

### DIFF
--- a/datasets/pascalvoc_to_tfrecords.py
+++ b/datasets/pascalvoc_to_tfrecords.py
@@ -79,8 +79,8 @@ def _process_image(directory, name):
       width: integer, image width in pixels.
     """
     # Read the image file.
-    filename = directory + DIRECTORY_IMAGES + name + '.jpg'
-    image_data = tf.gfile.FastGFile(filename, 'r').read()
+    filename = os.path.join(directory, DIRECTORY_IMAGES, '{}.jpg'.format(name))
+    image_data = tf.gfile.FastGFile(filename, 'rb').read()
 
     # Read the XML annotation file.
     filename = os.path.join(directory, DIRECTORY_ANNOTATIONS, name + '.xml')


### PR DESCRIPTION
- replace `+` to `os.path.join`
  - didn't work with `--dataset_dir` without trailing slash (#73)
- use 'rb' mode on `tf.gfile.FastGFile`
  - didn't work with Python3