### PR TITLE
Fixed a bug in with image_read 

### DIFF
--- a/datasets/pascalvoc_to_tfrecords.py
+++ b/datasets/pascalvoc_to_tfrecords.py
@@ -80,7 +80,7 @@ def _process_image(directory, name):
     """
     # Read the image file.
     filename = directory + DIRECTORY_IMAGES + name + '.jpg'
-    image_data = tf.gfile.FastGFile(filename, 'r').read()
+    image_data = tf.gfile.FastGFile(filename, 'rb').read()
 
     # Read the XML annotation file.
     filename = os.path.join(directory, DIRECTORY_ANNOTATIONS, name + '.xml')


### PR DESCRIPTION
Image file in pascal_to_tfrecords should be opened as binary, otherwise it gives encoding error as raised in issues.