### PR TITLE
fix missing 'isdifficult' in tfrecords and add ssd preprocessing pipeline

### DIFF
--- a/datasets/pascalvoc_to_tfrecords.py
+++ b/datasets/pascalvoc_to_tfrecords.py
@@ -103,12 +103,15 @@ def _process_image(directory, name):
         labels.append(int(VOC_LABELS[label][0]))
         labels_text.append(label.encode('ascii'))
 
-        if obj.find('difficult'):
-            difficult.append(int(obj.find('difficult').text))
+        isdifficult = obj.find('difficult')
+        if isdifficult is not None:
+            difficult.append(int(isdifficult.text))
         else:
             difficult.append(0)
-        if obj.find('truncated'):
-            truncated.append(int(obj.find('truncated').text))
+
+        istruncated = obj.find('truncated')
+        if istruncated is not None:
+            truncated.append(int(istruncated.text))
         else:
             truncated.append(0)
 


### PR DESCRIPTION
'if obj.find('difficult'):' will never passed, see the bottom at [https://docs.python.org/2/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element
](url)
the original implementation of SSD used one special preprocessing pipeline, now is available in Tensorflow