### PR TITLE
improved code robustness

### DIFF
--- a/notebooks/ssd_notebook.ipynb
+++ b/notebooks/ssd_notebook.ipynb
@@ -47,7 +47,7 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "sys.path.append('../')"
+    "sys.path.insert(0, '../')"
    ]
   },
   {


### PR DESCRIPTION
if  a man have "nets" folder in his path, he will can not run cell 4.
he will get error "cannot import name 'ssd_vgg_300'", my pull request solve the problem.